### PR TITLE
add data modeling caveat for image store example

### DIFF
--- a/blobs_java_driver/src/main/java/CassandraImageStore.java
+++ b/blobs_java_driver/src/main/java/CassandraImageStore.java
@@ -22,6 +22,10 @@ import java.util.List;
  * limitations under the License.
  */
 public class CassandraImageStore {
+    /* The code below is intended as a usage example for the blob datatype,
+     * not as data modeling advice. Cassandra is not designed to be a file
+     * store and is unlikely to work well as such.
+     */
 
     private final Session session;
     private final Cluster cluster;


### PR DESCRIPTION
I spoke briefly with a user who was running into problems using a DataStax product as an image store, and who cited this example when describing their data model.

I've proposed here a caveat in a comment, but I'm not sure it goes far enough. I think it's worth considering rewriting this to serve strictly as a blob-usage example, so readers won't interpret example as an endorsement of C*-based DBs as a file storage system.